### PR TITLE
Skip after-inference rewrite passes for stencil pipeline

### DIFF
--- a/numba/stencilparfor.py
+++ b/numba/stencilparfor.py
@@ -522,9 +522,6 @@ def get_stencil_blocks(sf, typingctx, args, scope, loc, input_dict, typemap,
             return_type=tp.return_type,
             html_output=numba.config.HTML)
 
-        numba.rewrites.rewrite_registry.apply(
-            'after-inference', tp, tp.func_ir)
-
     # make block labels unique
     stencil_blocks = ir_utils.add_offset_to_labels(stencil_blocks,
                                                         ir_utils.next_label())

--- a/numba/typeinfer.py
+++ b/numba/typeinfer.py
@@ -1209,8 +1209,6 @@ class TypeInferer(object):
                                               loc=inst.loc))
         elif expr.op == 'make_function':
             self.lock_type(target.name, types.pyfunc_type, loc=inst.loc)
-        elif expr.op == 'arrayexpr':
-            self.add_type(target.name, expr.ty, loc=inst.loc)
         else:
             raise NotImplementedError(type(expr), expr)
 


### PR DESCRIPTION
to avoid the need for handling arrayexpr node (and other lowering specific node) in typeinfer.

This is to address: https://github.com/IntelLabs/numba/pull/37#discussion_r145550213

Since the arrayexpr rewrite pass is a lowering specific pass, it does not seem to be needed for the the stencil `DummyPipeline` where only the typed IR is needed.  When the stencil kernel IR is later inlined into the parfor-gufunc, the arrayexpr rewrite pass will be applied and any optimization on arrayexpr will not be missed.