### PR TITLE
Core pa preparfor

### DIFF
--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -1239,8 +1239,6 @@ def merge_adjacent_blocks(blocks):
             removed.add(next_label)
             label = next_label
 
-    cfg = compute_cfg_from_blocks(blocks)
-
 def restore_copy_var_names(blocks, save_copies, typemap):
     """
     restores variable names of user variables after applying copy propagation

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -300,6 +300,7 @@ class ParforPass(object):
         if self.options.numpy:
             self._replace_parallel_functions(self.func_ir.blocks)
         # run array analysis, a pre-requisite for parfor translation
+        remove_dels(self.func_ir.blocks)
         self.array_analysis.run(self.func_ir.blocks)
         # run stencil translation to parfor
         if self.options.stencil:

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -376,7 +376,7 @@ def lower_get_type_min_value(context, builder, sig, args):
     return impl_ret_untracked(context, builder, lty, res)
 
 @lower_builtin(get_type_max_value, types.DType)
-def lower_get_type_min_value(context, builder, sig, args):
+def lower_get_type_max_value(context, builder, sig, args):
     typ = sig.args[0].dtype
     bw = typ.bitwidth
 

--- a/numba/targets/builtins.py
+++ b/numba/targets/builtins.py
@@ -355,6 +355,7 @@ def get_type_min_value(typ):
         return typ.minval
     raise NotImplementedError("Unsupported type")
 
+@lower_builtin(get_type_min_value, types.NumberClass)
 @lower_builtin(get_type_min_value, types.DType)
 def lower_get_type_min_value(context, builder, sig, args):
     typ = sig.args[0].dtype
@@ -375,6 +376,7 @@ def lower_get_type_min_value(context, builder, sig, args):
         res = ir.Constant(lty, np.finfo(npty).min)
     return impl_ret_untracked(context, builder, lty, res)
 
+@lower_builtin(get_type_max_value, types.NumberClass)
 @lower_builtin(get_type_max_value, types.DType)
 def lower_get_type_max_value(context, builder, sig, args):
     typ = sig.args[0].dtype

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -174,6 +174,10 @@ def countParfors(test_func, args, **kws):
             return_type=tp.return_type,
             html_output=config.HTML)
 
+        preparfor_pass = numba.parfor.PreParforPass(
+            tp.func_ir, tp.typemap, tp.calltypes, tp.typingctx, options)
+        preparfor_pass.run()
+
         numba.rewrites.rewrite_registry.apply(
             'after-inference', tp, tp.func_ir)
 

--- a/numba/typing/builtins.py
+++ b/numba/typing/builtins.py
@@ -920,7 +920,7 @@ class MinValInfer(AbstractTemplate):
     def generic(self, args, kws):
         assert not kws
         assert len(args) == 1
-        assert isinstance(args[0], types.DType)
+        assert isinstance(args[0], (types.DType, types.NumberClass))
         return signature(args[0].dtype, *args)
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
I decide to keep the name "preparfor" for this new pass, because it is not meant to run when `parallel=False`.

All tests should pass (except the `test_kde_example` as noted in #49). This PR paves the work for simplifying reduction implementation, which will be another PR I'll submit after this is reviewed.