### PR TITLE
Reduction implementation simplification

### DIFF
--- a/numba/__init__.py
+++ b/numba/__init__.py
@@ -9,7 +9,7 @@ import sys
 from . import config, errors, runtests, types
 
 # Re-export typeof
-from .special import typeof, prange
+from .special import typeof, prange, pndindex
 
 # Re-export error classes
 from .errors import *

--- a/numba/ir_utils.py
+++ b/numba/ir_utils.py
@@ -496,7 +496,6 @@ def remove_dead(blocks, args, typemap=None, alias_map=None, arg_aliases=None):
         # find live variables at the end of block
         for out_blk, _data in cfg.successors(label):
             lives |= live_map[out_blk]
-        lives |= arg_aliases
         removed |= remove_dead_block(block, lives, call_table, arg_aliases, alias_map, alias_set, typemap)
     return removed
 
@@ -521,7 +520,7 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map, alias_se
     for stmt in reversed(block.body[:-1]):
         # aliases of lives are also live
         alias_lives = set()
-        init_alias_lives = lives & alias_set
+        init_alias_lives = (lives | arg_aliases) & alias_set
         for v in init_alias_lives:
             alias_lives |= alias_map[v]
         # let external calls handle stmt if type matches
@@ -544,7 +543,8 @@ def remove_dead_block(block, lives, call_table, arg_aliases, alias_map, alias_se
                 continue
             # TODO: remove other nodes like SetItem etc.
         if isinstance(stmt, ir.SetItem):
-            if stmt.target.name not in lives and stmt.target.name not in alias_lives:
+            name = stmt.target.name
+            if not (name in lives or name in alias_lives or name in arg_aliases):
                 continue
 
         if type(stmt) in analysis.ir_extension_usedefs:

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -220,7 +220,7 @@ def arange_parallel_impl(return_type, *args):
             nitems_c = (stop - start) / step
             nitems_r = math.ceil(nitems_c.real)
             nitems_i = math.ceil(nitems_c.imag)
-            nitems = max(min(nitems_i, nitems_r), 0)
+            nitems = int(max(min(nitems_i, nitems_r), 0))
             arr = np.empty(nitems, dtype)
             for i in numba.parfor.internal_prange(nitems):
                 arr[i] = start + i * step
@@ -229,7 +229,7 @@ def arange_parallel_impl(return_type, *args):
         def arange_4(start, stop, step, dtype):
             numba.parfor.init_prange()
             nitems_r = math.ceil((stop - start) / step)
-            nitems = max(nitems_r, 0)
+            nitems = int(max(nitems_r, 0))
             arr = np.empty(nitems, dtype)
             val = start
             for i in numba.parfor.internal_prange(nitems):

--- a/numba/parfor.py
+++ b/numba/parfor.py
@@ -2246,7 +2246,8 @@ def remove_dead_parfor(parfor, lives, arg_aliases, alias_map, typemap):
         for v in alias_lives:
             in_lives |= alias_map[v]
         if (isinstance(stmt, ir.SetItem) and stmt.index.name ==
-                parfor.index_var.name and stmt.target.name not in in_lives):
+                parfor.index_var.name and stmt.target.name not in in_lives and
+                stmt.target.name not in arg_aliases):
             continue
         in_lives |= {v.name for v in stmt.list_vars()}
         new_body.append(stmt)

--- a/numba/special.py
+++ b/numba/special.py
@@ -1,6 +1,13 @@
 from __future__ import print_function, division, absolute_import
 
 from .typing.typeof import typeof
-from .parfor import prange
+import numpy as np
 
-__all__ = ['typeof', 'prange']
+def pndindex(*args):
+    return np.ndindex(*args)
+
+class prange(object):
+    def __new__(cls, *args):
+        return range(*args)
+
+__all__ = ['typeof', 'prange', 'pndindex']

--- a/numba/targets/arrayobj.py
+++ b/numba/targets/arrayobj.py
@@ -14,7 +14,7 @@ from llvmlite.llvmpy.core import Constant
 
 import numpy as np
 
-from numba import types, cgutils, typing, utils, extending
+from numba import types, cgutils, typing, utils, extending, pndindex
 from numba.numpy_support import as_dtype, carray, farray
 from numba.numpy_support import version as numpy_version
 from numba.targets.imputils import (lower_builtin, lower_getattr,
@@ -2908,6 +2908,7 @@ def iternext_numpy_nditer(context, builder, sig, args, result):
     nditer.iternext_specific(context, builder, arrty, arr, result)
 
 
+@lower_builtin(pndindex, types.VarArg(types.Integer))
 @lower_builtin(np.ndindex, types.VarArg(types.Integer))
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(*shape)"""
@@ -2921,6 +2922,7 @@ def make_array_ndindex(context, builder, sig, args):
     res = nditer._getvalue()
     return impl_ret_borrowed(context, builder, sig.return_type, res)
 
+@lower_builtin(pndindex, types.BaseTuple)
 @lower_builtin(np.ndindex, types.BaseTuple)
 def make_array_ndindex(context, builder, sig, args):
     """ndindex(shape)"""

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -300,7 +300,7 @@ class TestParfors(TestParforsBase):
     def test_test2(self):
         args = (numba.float64[:], numba.float64[:,:], numba.float64[:],
                 numba.int64)
-        self.assertTrue(countParfors(test2, args) == 2)
+        self.assertTrue(countParfors(test2, args) == 1)
 
     @skip_unsupported
     @tag('important')
@@ -1239,7 +1239,7 @@ class TestParforsSlice(TestParforsBase):
             b[0:(n-1)] = 10
             return a * b
 
-        self.check(test_impl, np.ones(10), np.zeros(10), 2)
+        self.check(test_impl, np.ones(10), np.zeros(10), 8)
         args = (numba.float64[:], numba.float64[:], numba.int64)
         self.assertEqual(countParfors(test_impl, args), 2)
 

--- a/numba/typing/npydecl.py
+++ b/numba/typing/npydecl.py
@@ -15,6 +15,7 @@ from ..numpy_support import (ufunc_find_matching_loop,
 from ..numpy_support import version as numpy_version
 from ..errors import TypingError
 from ..config import PerformanceWarning
+from numba import pndindex
 
 registry = Registry()
 infer = registry.register
@@ -1045,6 +1046,7 @@ class NdIter(AbstractTemplate):
         return signature(nditerty, *args)
 
 
+@infer_global(pndindex)
 @infer_global(np.ndindex)
 class NdIndex(AbstractTemplate):
 


### PR DESCRIPTION
Add `pndindex` as another parallel iterator in addition to `prange`, mirroring the sequential counter part `ndindex`.

So function `_convert_prange` is now called `_convert_loop`, processes loops from inner to outer, and is no longer nested.

Simplify the implementation of reduction implementation by directly giving parallel implementations as Python functions using either `pndindex` or `prange`, which are inlined in preparfor stage.

Also pass return type as the argument to the parallel function implementors, which helps type inference.

Translate `reduce(A[M])` to a single loop when `M` is a boolean array. The case where the actual reduction is being implemented as `pndindex` loop is also handled.