### PR TITLE
More fastmath tests

### DIFF
--- a/numba/npyufunc/wrappers.py
+++ b/numba/npyufunc/wrappers.py
@@ -326,7 +326,7 @@ class _GufuncWrapper(object):
         fnty = Type.function(Type.void(), [byte_ptr_ptr_t, intp_ptr_t,
                                            intp_ptr_t, byte_ptr_t])
 
-        wrapper_module = library.create_ir_module('')
+        wrapper_module = library.create_ir_module('_gufunc_wrapper')
         func_type = self.call_conv.get_function_type(self.fndesc.restype,
                                                      self.fndesc.argtypes)
         fname = self.fndesc.llvm_func_name

--- a/numba/runtime/nrtopt.py
+++ b/numba/runtime/nrtopt.py
@@ -4,6 +4,7 @@ NRT specific optimizations
 import re
 from collections import defaultdict, deque
 from llvmlite import binding as ll
+from numba import cgutils
 
 _regex_incref = re.compile(r'\s*(?:tail)?\s*call void @NRT_incref\((.*)\)')
 _regex_decref = re.compile(r'\s*(?:tail)?\s*call void @NRT_decref\((.*)\)')
@@ -161,5 +162,10 @@ def remove_redundant_nrt_refct(ll_module):
     except NameError:
         return ll_module
 
+    # the optimisation pass loses the name of module as it operates on
+    # strings, so back it up and reset it on completion
+    name = ll_module.name
     newll = _remove_redundant_nrt_refct(str(ll_module))
-    return ll.parse_assembly(newll)
+    new_mod = ll.parse_assembly(newll)
+    new_mod.name = cgutils.normalize_ir_text(name)
+    return new_mod

--- a/numba/tests/test_parfors.py
+++ b/numba/tests/test_parfors.py
@@ -6,6 +6,7 @@
 from __future__ import print_function, division, absolute_import
 
 from math import sqrt
+import numbers
 import re
 import sys
 import types as pytypes
@@ -29,7 +30,7 @@ from numba.ir_utils import (copy_propagate, apply_copy_propagate,
 from numba import ir
 from numba.compiler import compile_isolated, Flags
 from numba.bytecode import ByteCodeIter
-from .support import tag
+from .support import tag, override_env_config
 from .matmul_usecase import needs_blas
 from .test_linalg import needs_lapack
 
@@ -39,6 +40,8 @@ _windows_py27 = (sys.platform.startswith('win32') and
 _32bit = sys.maxsize <= 2 ** 32
 _reason = 'parfors not supported'
 skip_unsupported = unittest.skipIf(_32bit or _windows_py27, _reason)
+_lnx_reason = 'linux only test'
+linux_only = unittest.skipIf(not sys.platform.startswith('linux'), _lnx_reason)
 
 
 class TestParforsBase(TestCase):
@@ -57,6 +60,12 @@ class TestParforsBase(TestCase):
         self.pflags = Flags()
         self.pflags.set('auto_parallel', cpu.ParallelOptions(True))
         self.pflags.set('nrt')
+
+        # flags for njit(parallel=True, fastmath=True)
+        self.fast_pflags = Flags()
+        self.fast_pflags.set('auto_parallel', cpu.ParallelOptions(True))
+        self.fast_pflags.set('nrt')
+        self.fast_pflags.set('fastmath')
         super(TestParforsBase, self).__init__(*args)
 
     def _compile_this(self, func, sig, flags):
@@ -64,6 +73,9 @@ class TestParforsBase(TestCase):
 
     def compile_parallel(self, func, sig):
         return self._compile_this(func, sig, flags=self.pflags)
+
+    def compile_parallel_fastmath(self, func, sig):
+        return self._compile_this(func, sig, flags=self.fast_pflags)
 
     def compile_njit(self, func, sig):
         return self._compile_this(func, sig, flags=self.cflags)
@@ -92,22 +104,51 @@ class TestParforsBase(TestCase):
             scheduler_type - 'signed', 'unsigned' or None, default is None.
                            Supply in cases where the presence of a specific
                            scheduler is to be asserted.
+            fastmath_pcres - a fastmath parallel compile result, if supplied
+                             will be run to make sure the result is correct
             Remaining kwargs are passed to np.testing.assert_almost_equal
         """
         scheduler_type = kwargs.pop('scheduler_type', None)
+        check_fastmath = kwargs.pop('check_fastmath', None)
+        fastmath_pcres = kwargs.pop('fastmath_pcres', None)
+
+        def copy_args(*args):
+            if not args:
+                return tuple()
+            new_args = []
+            for x in args:
+                if isinstance(x, np.ndarray):
+                    new_args.append(x.copy('k'))
+                elif isinstance(x, np.number):
+                    new_args.append(x.copy())
+                elif isinstance(x, numbers.Number):
+                    new_args.append(x)
+                else:
+                    raise ValueError('Unsupported argument type encountered')
+            return tuple(new_args)
 
         # python result
-        py_expected = pyfunc(*args)
+        py_expected = pyfunc(*copy_args(*args))
 
         # njit result
-        njit_output = cfunc.entry_point(*args)
+        njit_output = cfunc.entry_point(*copy_args(*args))
 
         # parfor result
-        parfor_output = cpfunc.entry_point(*args)
+        parfor_output = cpfunc.entry_point(*copy_args(*args))
 
         np.testing.assert_almost_equal(njit_output, py_expected, **kwargs)
         np.testing.assert_almost_equal(parfor_output, py_expected, **kwargs)
 
+        self.check_scheduling(cpfunc, scheduler_type)
+
+        # if requested check fastmath variant
+        if fastmath_pcres is not None:
+            parfor_fastmath_output = fastmath_pcres.entry_point(*copy_args(*args))
+            np.testing.assert_almost_equal(parfor_fastmath_output, py_expected,
+                                           **kwargs)
+
+
+    def check_scheduling(self, cres, scheduler_type):
         # make sure parfor set up scheduling
         scheduler_str = '@do_scheduling'
         if scheduler_type is not None:
@@ -117,7 +158,90 @@ class TestParforsBase(TestCase):
                 msg = "Unknown scheduler_type specified: %s"
                 raise ValueError(msg % scheduler_type)
 
-        self.assertIn(scheduler_str, cpfunc.library.get_llvm_str())
+        self.assertIn(scheduler_str, cres.library.get_llvm_str())
+
+    def _filter_mod(self, mod, magicstr, checkstr=None):
+        """ helper function to filter out modules by name"""
+        filt = [x for x in mod if magicstr in x.name]
+        if checkstr is not None:
+            for x in filt:
+                assert checkstr in str(x)
+        return filt
+
+    def _get_gufunc_modules(self, cres, magicstr, checkstr=None):
+        """ gets the gufunc LLVM Modules"""
+        _modules = [x for x in cres.library._codegen._engine._ee._modules]
+        return self._filter_mod(_modules, magicstr, checkstr=checkstr)
+
+    def _get_gufunc_info(self, cres, fn):
+        """ helper for gufunc IR/asm generation"""
+        # get the gufunc modules
+        magicstr = '__numba_parfor_gufunc'
+        gufunc_mods = self._get_gufunc_modules(cres, magicstr)
+        x = dict()
+        for mod in gufunc_mods:
+            x[mod.name] = fn(mod)
+        return x
+
+    def _get_gufunc_ir(self, cres):
+        """
+        Returns the IR of the gufuncs used as parfor kernels
+        as a dict mapping the gufunc name to its IR.
+
+        Arguments:
+         cres - a CompileResult from `njit(parallel=True, ...)`
+        """
+        return self._get_gufunc_info(cres, str)
+
+    def _get_gufunc_asm(self, cres):
+        """
+        Returns the assembly of the gufuncs used as parfor kernels
+        as a dict mapping the gufunc name to its assembly.
+
+        Arguments:
+         cres - a CompileResult from `njit(parallel=True, ...)`
+        """
+        tm = cres.library._codegen._tm
+        def emit_asm(mod):
+            return str(tm.emit_assembly(mod))
+        return self._get_gufunc_info(cres, emit_asm)
+
+    def assert_fastmath(self, pyfunc, sig):
+        """
+        Asserts that the fastmath flag has some effect in that suitable
+        instructions are now labelled as `fast`. Whether LLVM can actually do
+        anything to optimise better now the derestrictions are supplied is
+        another matter!
+
+        Arguments:
+         pyfunc - a function that contains operations with parallel semantics
+         sig - the type signature of pyfunc
+        """
+
+        cres = self.compile_parallel_fastmath(pyfunc, sig)
+        _ir = self._get_gufunc_ir(cres)
+
+        def _get_fast_instructions(ir):
+            splitted = ir.splitlines()
+            fast_inst = []
+            for x in splitted:
+                if 'fast' in x:
+                    fast_inst.append(x)
+            return fast_inst
+
+        def _assert_fast(instrs):
+            ops = ('fadd', 'fsub', 'fmul', 'fdiv', 'frem', 'fcmp')
+            for inst in instrs:
+                count = 0
+                for op in ops:
+                    match = op + ' fast'
+                    if match in inst:
+                        count += 1
+                self.assertTrue(count > 0)
+
+        for name, guir in _ir.items():
+            inst = _get_fast_instructions(guir)
+            _assert_fast(inst)
 
 
 def test1(sptprice, strike, rate, volatility, timev):
@@ -771,75 +895,22 @@ class TestParfors(TestParforsBase):
         self.check(test_impl2, B)
         self.check(test_impl2, C)
 
-class TestPrange(TestParforsBase):
 
-    def prange_tester(self, pyfunc, *args, **kwargs):
+class TestPrangeBase(TestParforsBase):
+
+    def __init__(self, *args):
+        TestParforsBase.__init__(self, *args)
+
+    def generate_prange_func(self, pyfunc, patch_instance):
         """
-        The `prange` tester
-        This is a hack. It basically switches out range calls for prange.
-        It does this by copying the live code object of a function
-        containing 'range' then copying the .co_names and mutating it so
-        that 'range' is replaced with 'prange'. It then creates a new code
-        object containing the mutation and instantiates a function to contain
-        it. At this point three results are created:
-        1. The result of calling the original python function.
-        2. The result of calling a njit compiled version of the original
-            python function.
-        3. The result of calling a njit(parallel=True) version of the mutated
-           function containing `prange`.
-        The three results are then compared and the `prange` based function's
-        llvm_ir is inspected to ensure the scheduler code is present.
-
-        Arguments:
-         pyfunc - the python function to test
-         args - data arguments to pass to the pyfunc under test
-
-        Keyword Arguments:
-         patch_instance - iterable containing which instances of `range` to
-                          replace. If not present all instance of `range` are
-                          replaced.
-         scheduler_type - 'signed', 'unsigned' or None, default is None.
-                           Supply in cases where the presence of a specific
-                           scheduler is to be asserted.
-         Remaining kwargs are passed to np.testing.assert_almost_equal
-
-
-        Example:
-            def foo():
-                acc = 0
-                for x in range(5):
-                    for y in range(10):
-                        acc +=1
-                return acc
-
-            # calling as
-            prange_tester(foo)
-            # will test code equivalent to
-            # def foo():
-            #     acc = 0
-            #     for x in prange(5): # <- changed
-            #         for y in prange(10): # <- changed
-            #             acc +=1
-            #     return acc
-
-            # calling as
-            prange_tester(foo, patch_instance=[1])
-            # will test code equivalent to
-            # def foo():
-            #     acc = 0
-            #     for x in range(5): # <- outer loop (0) unchanged
-            #         for y in prange(10): # <- inner loop (1) changed
-            #             acc +=1
-            #     return acc
-
+        This function does the actual code augmentation to enable the explicit
+        testing of `prange` calls in place of `range`.
         """
-
         pyfunc_code = pyfunc.__code__
 
         prange_names = list(pyfunc_code.co_names)
 
-        patch_instance = kwargs.pop('patch_instance', None)
-        if not patch_instance:
+        if patch_instance is None:
             # patch all instances, cheat by just switching
             # range for prange
             assert 'range' in pyfunc_code.co_names
@@ -893,6 +964,79 @@ class TestPrange(TestParforsBase):
         # get function
         pfunc = pytypes.FunctionType(prange_code, globals())
 
+        return pfunc
+
+    def prange_tester(self, pyfunc, *args, **kwargs):
+        """
+        The `prange` tester
+        This is a hack. It basically switches out range calls for prange.
+        It does this by copying the live code object of a function
+        containing 'range' then copying the .co_names and mutating it so
+        that 'range' is replaced with 'prange'. It then creates a new code
+        object containing the mutation and instantiates a function to contain
+        it. At this point three results are created:
+        1. The result of calling the original python function.
+        2. The result of calling a njit compiled version of the original
+            python function.
+        3. The result of calling a njit(parallel=True) version of the mutated
+           function containing `prange`.
+        The three results are then compared and the `prange` based function's
+        llvm_ir is inspected to ensure the scheduler code is present.
+
+        Arguments:
+         pyfunc - the python function to test
+         args - data arguments to pass to the pyfunc under test
+
+        Keyword Arguments:
+         patch_instance - iterable containing which instances of `range` to
+                          replace. If not present all instance of `range` are
+                          replaced.
+         scheduler_type - 'signed', 'unsigned' or None, default is None.
+                           Supply in cases where the presence of a specific
+                           scheduler is to be asserted.
+         check_fastmath - if True then a check will be performed to ensure the
+                          IR contains instructions labelled with 'fast'
+         check_fastmath_result - if True then a check will be performed to
+                                 ensure the result of running with fastmath
+                                 on matches that of the pyfunc
+         Remaining kwargs are passed to np.testing.assert_almost_equal
+
+
+        Example:
+            def foo():
+                acc = 0
+                for x in range(5):
+                    for y in range(10):
+                        acc +=1
+                return acc
+
+            # calling as
+            prange_tester(foo)
+            # will test code equivalent to
+            # def foo():
+            #     acc = 0
+            #     for x in prange(5): # <- changed
+            #         for y in prange(10): # <- changed
+            #             acc +=1
+            #     return acc
+
+            # calling as
+            prange_tester(foo, patch_instance=[1])
+            # will test code equivalent to
+            # def foo():
+            #     acc = 0
+            #     for x in range(5): # <- outer loop (0) unchanged
+            #         for y in prange(10): # <- inner loop (1) changed
+            #             acc +=1
+            #     return acc
+
+        """
+        patch_instance = kwargs.pop('patch_instance', None)
+        check_fastmath = kwargs.pop('check_fastmath', False)
+        check_fastmath_result = kwargs.pop('check_fastmath_result', False)
+
+        pfunc = self.generate_prange_func(pyfunc, patch_instance)
+
         # Compile functions
         # compile a standard njit of the original function
         sig = tuple([numba.typeof(x) for x in args])
@@ -901,8 +1045,21 @@ class TestPrange(TestParforsBase):
         # compile the prange injected function
         cpfunc = self.compile_parallel(pfunc, sig)
 
-        # compare
+        # if check_fastmath is True then check fast instructions
+        if check_fastmath:
+            self.assert_fastmath(pfunc, sig)
+
+        # if check_fastmath_result is True then compile a function
+        # so that the parfors checker can assert the result is ok.
+        if check_fastmath_result:
+            fastcpfunc = self.compile_parallel_fastmath(pfunc, sig)
+            kwargs = dict({'fastmath_pcres': fastcpfunc}, **kwargs)
+
         self.check_parfors_vs_others(pyfunc, cfunc, cpfunc, *args, **kwargs)
+
+
+class TestPrange(TestPrangeBase):
+    """ Tests Prange """
 
     @skip_unsupported
     def test_prange01(self):
@@ -912,7 +1069,8 @@ class TestPrange(TestParforsBase):
             for i in range(n):
                 A[i] = 2.0 * i
             return A
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange02(self):
@@ -922,7 +1080,8 @@ class TestPrange(TestParforsBase):
             for i in range(1, n):
                 A[i - 1] = 2.0 * i
             return A
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange03(self):
@@ -931,7 +1090,8 @@ class TestPrange(TestParforsBase):
             for i in range(10):
                 s += 2
             return s
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange04(self):
@@ -945,7 +1105,8 @@ class TestPrange(TestParforsBase):
                 else:
                     A[i] = 0
             return A
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange05(self):
@@ -956,7 +1117,8 @@ class TestPrange(TestParforsBase):
             for i in range(1, n - 1, 1):
                 s += A[i]
             return s
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange06(self):
@@ -967,7 +1129,8 @@ class TestPrange(TestParforsBase):
             for i in range(1, 1, 1):
                 s += A[i]
             return s
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange07(self):
@@ -978,7 +1141,8 @@ class TestPrange(TestParforsBase):
             for i in range(n, 1):
                 s += A[i]
             return s
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange08(self):
@@ -990,7 +1154,8 @@ class TestPrange(TestParforsBase):
                 for j in range(len(A)):
                     acc += A[i]
             return acc
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange08_1(self):
@@ -1002,7 +1167,8 @@ class TestPrange(TestParforsBase):
                 for j in range(4):
                     acc += A[i]
             return acc
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange09(self):
@@ -1014,7 +1180,9 @@ class TestPrange(TestParforsBase):
                     acc += 1
             return acc
         # patch inner loop to 'prange'
-        self.prange_tester(test_impl, patch_instance=[1], scheduler_type='unsigned')
+        self.prange_tester(test_impl, patch_instance=[1],
+                           scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange10(self):
@@ -1028,7 +1196,9 @@ class TestPrange(TestParforsBase):
                 acc2 += acc1
             return acc2
         # patch outer loop to 'prange'
-        self.prange_tester(test_impl, patch_instance=[0], scheduler_type='unsigned')
+        self.prange_tester(test_impl, patch_instance=[0],
+                           scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     @unittest.skip("list append is not thread-safe yet (#2391, #2408)")
@@ -1036,7 +1206,8 @@ class TestPrange(TestParforsBase):
         def test_impl():
             n = 4
             return [np.sin(j) for j in range(n)]
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange12(self):
@@ -1047,7 +1218,8 @@ class TestPrange(TestParforsBase):
             for i in range(-len(X)):
                 acc += X[i]
             return acc
-        self.prange_tester(test_impl, scheduler_type='unsigned')
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange13(self):
@@ -1056,7 +1228,8 @@ class TestPrange(TestParforsBase):
             for i in range(n):
                 acc += 1
             return acc
-        self.prange_tester(test_impl, np.int32(4), scheduler_type='unsigned')
+        self.prange_tester(test_impl, np.int32(4), scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange14(self):
@@ -1068,7 +1241,9 @@ class TestPrange(TestParforsBase):
         # this tests reduction detection well since the accumulated variable
         # is initialized before the parfor and the value accessed from the array
         # is updated before accumulation
-        self.prange_tester(test_impl, np.random.ranf(4), scheduler_type='unsigned')
+        self.prange_tester(test_impl, np.random.ranf(4),
+                           scheduler_type='unsigned',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange15(self):
@@ -1080,7 +1255,8 @@ class TestPrange(TestParforsBase):
                 x = np.ones((1, 1))
                 acc += x[0, 0]
             return acc
-        self.prange_tester(test_impl, 1024, scheduler_type='unsigned')
+        self.prange_tester(test_impl, 1024, scheduler_type='unsigned',
+                           check_fastmath=True)
 
     # Tests for negative ranges
     @skip_unsupported
@@ -1090,9 +1266,9 @@ class TestPrange(TestParforsBase):
             for i in range(-N, N):
                 acc += 2
             return acc
-        self.prange_tester(test_impl, 1024, scheduler_type='signed')
+        self.prange_tester(test_impl, 1024, scheduler_type='signed',
+                           check_fastmath=True)
 
-    # currently fails
     @skip_unsupported
     def test_prange17(self):
         def test_impl(N):
@@ -1101,9 +1277,9 @@ class TestPrange(TestParforsBase):
             for i in range(-N, N):
                 acc += X[i]
             return acc
-        self.prange_tester(test_impl, 9, scheduler_type='signed')
+        self.prange_tester(test_impl, 9, scheduler_type='signed',
+                           check_fastmath=True)
 
-    # currently fails
     @skip_unsupported
     def test_prange18(self):
         def test_impl(N):
@@ -1114,9 +1290,9 @@ class TestPrange(TestParforsBase):
                 for j in range(-4, N):
                     acc += X[j]
             return acc
-        self.prange_tester(test_impl, 9, scheduler_type='signed')
+        self.prange_tester(test_impl, 9, scheduler_type='signed',
+                           check_fastmath=True)
 
-    # currently fails
     @skip_unsupported
     def test_prange19(self):
         def test_impl(N):
@@ -1127,9 +1303,9 @@ class TestPrange(TestParforsBase):
                 for j in range(-M, M):
                     acc += X[i, j]
             return acc
-        self.prange_tester(test_impl, 9, scheduler_type='signed')
+        self.prange_tester(test_impl, 9, scheduler_type='signed',
+                           check_fastmath=True)
 
-    # currently fails
     @skip_unsupported
     def test_prange20(self):
         def test_impl(N):
@@ -1138,7 +1314,8 @@ class TestPrange(TestParforsBase):
             for i in range(-1, N):
                 acc += X[i]
             return acc
-        self.prange_tester(test_impl, 9, scheduler_type='signed')
+        self.prange_tester(test_impl, 9, scheduler_type='signed',
+                           check_fastmath=True)
 
     @skip_unsupported
     def test_prange21(self):
@@ -1147,13 +1324,13 @@ class TestPrange(TestParforsBase):
             for i in range(-3, -1):
                 acc += 3
             return acc
-        self.prange_tester(test_impl, 9, scheduler_type='signed')
+        self.prange_tester(test_impl, 9, scheduler_type='signed',
+                           check_fastmath=True)
 
-    # segfaults
     @skip_unsupported
     def test_prange22(self):
         def test_impl():
-            a = 2
+            a = 0
             b = 3
             A = np.empty(4)
             for i in range(-2, 2):
@@ -1164,7 +1341,92 @@ class TestPrange(TestParforsBase):
                 else:
                     A[i] = 7
             return A
-        self.prange_tester(test_impl, scheduler_type='signed')
+        self.prange_tester(test_impl, scheduler_type='signed',
+                           check_fastmath=True, check_fastmath_result=True)
+
+    @skip_unsupported
+    def test_prange23(self):
+        # test non-contig input
+        def test_impl(A):
+            for i in range(len(A)):
+                A[i] = i
+            return A
+        A = np.zeros(32)[::2]
+        self.prange_tester(test_impl, A, scheduler_type='unsigned',
+                           check_fastmath=True, check_fastmath_result=True)
+
+    @skip_unsupported
+    def test_prange24(self):
+        # test non-contig input, signed range
+        def test_impl(A):
+            for i in range(-len(A), 0):
+                A[i] = i
+            return A
+        A = np.zeros(32)[::2]
+        self.prange_tester(test_impl, A, scheduler_type='signed',
+                           check_fastmath=True, check_fastmath_result=True)
+
+    # should this work?
+    @skip_unsupported
+    def test_prange25(self):
+        def test_impl(A):
+            B = A[::3]
+            for i in range(len(B)):
+                B[i] = i
+            return A
+        A = np.zeros(32)[::2]
+        self.prange_tester(test_impl, A, scheduler_type='unsigned',
+                           check_fastmath=True, check_fastmath_result=True)
+
+    @skip_unsupported
+    def test_check_error_model(self):
+        def test_impl():
+            n = 32
+            A = np.zeros(n)
+            for i in range(n):
+                A[i] = 1 / i # div-by-zero when i = 0
+            return A
+
+        with self.assertRaises(ZeroDivisionError) as raises:
+            test_impl()
+
+        # compile parallel functions
+        pfunc = self.generate_prange_func(test_impl, None)
+        pcres = self.compile_parallel(pfunc, ())
+        pfcres = self.compile_parallel_fastmath(pfunc, ())
+
+        # should raise
+        with self.assertRaises(ZeroDivisionError) as raises:
+            pcres.entry_point()
+
+        # should not raise
+        result = pfcres.entry_point()
+        self.assertEqual(result[0], np.inf)
+
+
+    @skip_unsupported
+    def test_check_alias_analysis(self):
+        # check alias analysis reports ok
+        def test_impl(A):
+            for i in range(len(A)):
+                B = A[i]
+                B[:] = 1
+            return A
+        A = np.zeros(32).reshape(4, 8)
+        self.prange_tester(test_impl, A, scheduler_type='unsigned',
+                           check_fastmath=True, check_fastmath_result=True)
+        pfunc = self.generate_prange_func(test_impl, None)
+        sig = tuple([numba.typeof(A)])
+        cres = self.compile_parallel_fastmath(pfunc, sig)
+        _ir = self._get_gufunc_ir(cres)
+        for k, v in _ir.items():
+            for line in v.splitlines():
+                # get the fn definition line
+                if 'define' in line and k in line:
+                    # there should only be 3x noalias, one on each of the first
+                    # 3 args (retptr, excinfo, env).
+                    self.assertEqual(line.count('noalias'), 3)
+                    break
 
     @skip_unsupported
     def test_prange_raises_invalid_step_size(self):
@@ -1178,6 +1440,37 @@ class TestPrange(TestParforsBase):
             self.prange_tester(test_impl, 1024)
         msg = 'Only constant step size of 1 is supported for prange'
         self.assertIn(msg, str(raises.exception))
+
+    @skip_unsupported
+    def test_prange_fastmath_check_works(self):
+        # this function will benefit from `fastmath`, the div will
+        # get optimised to a multiply by reciprocal and the accumulator
+        # then becomes an fmadd: A = A + i * 0.5
+        def test_impl():
+            n = 128
+            A = 0
+            for i in range(n):
+                A += i / 2.0
+            return A
+        self.prange_tester(test_impl, scheduler_type='unsigned',
+                           check_fastmath=True)
+        pfunc = self.generate_prange_func(test_impl, None)
+        cres = self.compile_parallel_fastmath(pfunc, ())
+        ir = self._get_gufunc_ir(cres)
+        _id = '%[A-Z]?.[0-9]+[.]?[i]?'
+        recipr_str = '\s+%s = fmul fast double %s, 5.000000e-01'
+        reciprocal_inst = re.compile(recipr_str % (_id, _id))
+        fadd_inst = re.compile('\s+%s = fadd fast double %s, %s'
+                               % (_id, _id, _id))
+        # check there is something like:
+        #  %.329 = fmul fast double %.325, 5.000000e-01
+        #  %.337 = fadd fast double %A.07, %.329
+        for name, kernel in ir.items():
+            splitted = kernel.splitlines()
+            for i, x in enumerate(splitted):
+                if reciprocal_inst.match(x):
+                    break
+            self.assertTrue(fadd_inst.match(splitted[i + 1]))
 
     @skip_unsupported
     def test_kde_example(self):
@@ -1232,6 +1525,200 @@ class TestPrange(TestParforsBase):
                   c[k] = i + j + k
             return b.sum()
         self.prange_tester(test_impl, 4)
+
+
+class TestParforsVectorizer(TestPrangeBase):
+
+    # env mutating test
+    _numba_parallel_test_ = False
+
+    def get_gufunc_asm(self, func, schedule_type, *args, fastmath=False,
+                       nkernels=2, cpu_name='skylake-avx512', assertions=True):
+
+        env_opts = {'NUMBA_CPU_NAME': cpu_name,
+                    'NUMBA_CPU_FEATURES': '',
+                    'NUMBA_NUM_THREADS': str(nkernels)
+                    }
+
+        overrides = []
+        for k, v in env_opts.items():
+            overrides.append(override_env_config(k, v))
+
+        with overrides[0], overrides[1], overrides[2]:
+            sig = tuple([numba.typeof(x) for x in args])
+            pfunc_vectorizable = self.generate_prange_func(func, None)
+            if fastmath == True:
+                cres = self.compile_parallel_fastmath(pfunc_vectorizable, sig)
+            else:
+                cres = self.compile_parallel(pfunc_vectorizable, sig)
+
+            # make sure there's `nkernels` schedule calls of the same type
+            schedty = re.compile('call\s+\w+\*\s+@do_scheduling_(\w+)\(')
+            matches = schedty.findall(cres.library.get_llvm_str())
+
+            # get the gufunc asm
+            asm = self._get_gufunc_asm(cres)
+
+            if assertions:
+                self.assertEqual(len(matches), 2)
+                self.assertEqual(matches[0], matches[1])
+                self.assertTrue(asm != {})
+
+        return asm
+
+    # this is a common match pattern for something like:
+    # \n\tvsqrtpd\t-192(%rbx,%rsi,8), %zmm0\n
+    # to check vsqrtpd oeprates on zmm
+    match_vsqrtpd_on_zmm = re.compile('\n\s+vsqrtpd\s+.*zmm.*\n')
+
+    @linux_only
+    def test_vectorizer_fastmath_asm(self):
+        """ This checks that if fastmath is set and the underlying hardware
+        is suitable, and the function supplied is amenable to fastmath based
+        vectorization, that the vectorizer actually runs.
+        """
+
+        # This function will benefit from `fastmath` if run on a suitable
+        # target. The vectorizer should unwind the loop and generate
+        # packed dtype=double add and sqrt instructions.
+        def will_vectorize(A):
+            n = len(A)
+            for i in range(n):
+                A[i] += np.sqrt(i)
+            return A
+
+        arg = np.zeros(10)
+
+        fast_asm = self.get_gufunc_asm(will_vectorize, 'unsigned', arg,
+                                       fastmath=True)
+        slow_asm = self.get_gufunc_asm(will_vectorize, 'unsigned', arg,
+                                       fastmath=False)
+
+        for v in fast_asm.values():
+            # should unwind and call vector sqrt then vector add 
+            # all on packed doubles using zmm's
+            self.assertTrue('vaddpd' in v)
+            self.assertTrue('vsqrtpd' in v)
+            self.assertTrue('zmm' in v)
+            # make sure vsqrtpd operates on zmm
+            self.assertTrue(len(self.match_vsqrtpd_on_zmm.findall(v)) > 1)
+
+        for v in slow_asm.values():
+            # vector variants should not be present
+            self.assertTrue('vaddpd' not in v)
+            self.assertTrue('vsqrtpd' not in v)
+            # check scalar variant is present
+            self.assertTrue('vsqrtsd' in v)
+            self.assertTrue('vaddsd' in v)
+            # check no zmm addressing is present
+            self.assertTrue('zmm' not in v)
+
+    @linux_only
+    def test_unsigned_refusal_to_vectorize(self):
+        """ This checks that if fastmath is set and the underlying hardware
+        is suitable, and the function supplied is amenable to fastmath based
+        vectorization, that the vectorizer actually runs.
+        """
+
+        def will_not_vectorize(A):
+            n = len(A)
+            for i in range(-n, 0):
+                A[i] = np.sqrt(A[i])
+            return A
+
+        def will_vectorize(A):
+            n = len(A)
+            for i in range(n):
+                A[i] = np.sqrt(A[i])
+            return A
+
+        arg = np.zeros(10)
+
+        novec_asm = self.get_gufunc_asm(will_not_vectorize, 'signed', arg,
+                                        fastmath=True)
+
+        vec_asm = self.get_gufunc_asm(will_vectorize, 'unsigned', arg,
+                                      fastmath=True)
+
+        for v in novec_asm.values():
+            # vector variant should not be present
+            self.assertTrue('vsqrtpd' not in v)
+            # check scalar variant is present
+            self.assertTrue('vsqrtsd' in v)
+            # check no zmm addressing is present
+            self.assertTrue('zmm' not in v)
+
+        for v in vec_asm.values():
+            # should unwind and call vector sqrt then vector mov
+            # all on packed doubles using zmm's
+            self.assertTrue('vsqrtpd' in v)
+            self.assertTrue('vmovupd' in v)
+            self.assertTrue('zmm' in v)
+            # make sure vsqrtpd operates on zmm
+            self.assertTrue(len(self.match_vsqrtpd_on_zmm.findall(v)) > 1)
+
+    @linux_only
+    def test_signed_vs_unsigned_vec_asm(self):
+        """ This checks vectorization for signed vs unsigned variants of a
+        trivial accumulator, the only meaningful difference should be the
+        presence of signed vs. unsigned unpack instructions (for the
+        induction var).
+        """
+        def signed_variant():
+            n = 4096
+            A = 0.
+            for i in range(-n, 0):
+                A += i
+            return A
+
+        def unsigned_variant():
+            n = 4096
+            A = 0.
+            for i in range(n):
+                A += i
+            return A
+
+        signed_asm = self.get_gufunc_asm(signed_variant, 'signed',
+                                         fastmath=True)
+        unsigned_asm = self.get_gufunc_asm(unsigned_variant, 'unsigned',
+                                           fastmath=True)
+
+        def strip_instrs(asm):
+            acc = []
+            for x in asm.splitlines():
+                spd = x.strip()
+                # filter out anything that isn't a trivial instruction
+                # and anything with the gufunc id as it contains an address
+                if spd != '' and not (spd.startswith('.')
+                                     or spd.startswith('_') 
+                                     or spd.startswith('"')
+                                     or '__numba_parfor_gufunc' in spd):
+                        acc.append(re.sub('[\t]', '', spd))
+            return acc
+
+        for k, v in signed_asm.items():
+            signed_instr = strip_instrs(v)
+            break
+
+        for k, v in unsigned_asm.items():
+            unsigned_instr = strip_instrs(v)
+            break
+
+        from difflib import SequenceMatcher as sm
+        # make sure that the only difference in instruction (if there is a
+        # difference) is the char 'u'. For example:
+        # vcvtsi2sdq vs. vcvtusi2sdq
+        self.assertEqual(len(signed_instr), len(unsigned_instr))
+        for a, b in zip(signed_instr, unsigned_instr):
+            if a == b:
+                continue
+            else:
+                s = sm(lambda x: x == '\t', a, b)
+                ops = s.get_opcodes()
+                for op in ops:
+                    if op[0] == 'insert':
+                        self.assertEqual(b[op[-2]:op[-1]], 'u')
+
 
 class TestParforsSlice(TestParforsBase):
 


### PR DESCRIPTION
This adds tests for:
 * Ensuring that fastmath flags propagate and are applied to
   the LLVM IR.
 * Ensuring the vectorizer produces vector instructions under
   various different circumstances.
 * Ensuring appropriate error models are in use.
 * Alias analysis output
 * Parallel=True and non-contiguous input

It also fixes a bug in the ref count optimizer that was causing the
LLVM module name to be lost.